### PR TITLE
Removed no-underscore-dangle rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,6 +16,8 @@ module.exports = {
     ],
     rules: {
         indent: ['error', 4],
+        'comma-dangle': ['error', 'never'],
+        'no-underscore-dangle': 'allow',
         'padded-blocks': ['error', 'never'],
         'max-len': [0, 200],
         'react/jsx-indent': [2, 4],

--- a/index.js
+++ b/index.js
@@ -16,7 +16,6 @@ module.exports = {
     ],
     rules: {
         indent: ['error', 4],
-        'comma-dangle': ['error', 'never'],
         'padded-blocks': ['error', 'never'],
         'max-len': [0, 200],
         'react/jsx-indent': [2, 4],


### PR DESCRIPTION
Is there a good reason why this is explicitly set?